### PR TITLE
Allow completion triggers with more than one character

### DIFF
--- a/ClangAutoComplete.py
+++ b/ClangAutoComplete.py
@@ -65,7 +65,7 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 		body = view.substr(sublime.Region(0, view.size()))
 
 		# Verify that character under the cursor is one allowed selector
-		if self.complete_all == False and any(e in body[pos-1:pos] for e in self.selectors) == False:
+		if self.complete_all == False and any(e in body[pos-len(e):pos] for e in self.selectors) == False:
 			return []
 		line_pos = body[:pos].count('\n')+1
 		char_pos = pos-body.rfind("\n", 0, len(body[:pos]))


### PR DESCRIPTION
Hi,

I started using the plugin today and it works well so far, great job! :)

I noticed that slight delays were introduced by the completion when typing some character combinations such as "::" (it gets called on the first ":") or expressions such as "a > b" (it gets called on ">" while it is useless here).

I made a small modification in the code so that users can now have trigger with more than one letter e.g. "->" and "::".

The only remaining problem is that Sublime Text does not support triggers with more than one character through its settings ("auto_complete_triggers") .
As a consequence, when typing "::", the default Sublime completion appears when typing the first ":" and the Clang one when typing the second ":".