### PR TITLE
Add support for new syntax file extension

### DIFF
--- a/ClangAutoComplete.py
+++ b/ClangAutoComplete.py
@@ -10,7 +10,7 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 
 	compl_regex = re.compile("COMPLETION: ([^ ]+) : ([^\\n]+)")
 	file_ext = re.compile("[^\.]+\.([^\\n]+)")
-	syntax_regex = re.compile("\/([^\/]+)\.tmLanguage")
+	syntax_regex = re.compile("\/([^\/]+)\.(?:tmLanguage|sublime-syntax)")
 	project_name_regex = re.compile("([^\.]+).sublime-project")
 	settings_time = 0
 


### PR DESCRIPTION
Sublime 3 build 3103 introduced new syntax file format with new
extension .sublime-syntax. Plugin uses name of current syntax
file to infer language, so regex is modified to accept new
extension.