### PR TITLE
cleanups and fixes to project path

### DIFF
--- a/ClangAutoComplete.py
+++ b/ClangAutoComplete.py
@@ -27,11 +27,19 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 
 		settings = sublime.load_settings("ClangAutoComplete.sublime-settings")
 
-		# Variable $project_base_path in settings will be replaced by sublime's project path
+		# initialize these to nothing in case they are not present in the variables
+		project_path=""
+		project_name=""
+		file_parent_folder=""
+
+		# these variables should be populated by sublime text
 		variables = sublime.active_window().extract_variables()
-		project_path = variables['folder']
-		project_name = variables['project_base_name']
-		file_parent_folder = path.join(path.dirname(variables['file']), "..")
+		if ('folder' in variables):
+			project_path = variables['folder']
+		if ('project_base_name' in variables):
+			project_name = variables['project_base_name']
+		if ('file' in variables):
+			file_parent_folder = path.join(path.dirname(variables['file']), "..")
 
 		include_parent_folder = self.to_bool(settings.get("include_file_parent_folder"))
 		self.complete_all = self.to_bool(settings.get("autocomplete_all"))
@@ -50,9 +58,8 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 			include_dir = os.path.abspath(include_dir)
 
 		if (self.verbose):
-			print("project_base_name = {}".format(variables['project_base_name']))
-			print("folder = {}".format(variables['folder']))
-			print("file = {}".format(variables['file']))
+			print("project_base_name = {}".format(project_name))
+			print("folder = {}".format(project_path))
 			print("file_parent_folder = {}".format(file_parent_folder))
 
 		if (include_parent_folder):

--- a/ClangAutoComplete.sublime-settings
+++ b/ClangAutoComplete.sublime-settings
@@ -9,17 +9,31 @@
 	// "tmp_file_path" : "/tmp/auto_complete_tmp",
 	/* If file encoding was not detected, assume this instead */
 	"default_encoding" : "UTF-8",
-	/* 
+	/*
 	 * If set to "true", auto-complete is always on, it will provide suggestions for any key press,
 	 * regardless what triggers are configured in "selectors".
 	 * It will slow down sublime, essentially re-compiling the file for every key press.
 	 */
 	"autocomplete_all" : "false",
-	/* 
+	/*
 	 * if autocomplete_all is set to false,
 	 * What triggers auto-completion process (should be same as sublime's own settings 
 	 */
 	"selectors" : [ ">","."],
+
+	/*
+	 * if verbose is set to false, the plugin will output nothing.
+	 * else it will show the paths that it has found.
+	 */
+	"verbose" : "true",
+
+	/*
+	 * if include_file_parent_folder is set to true, the parent folder of the
+	 * current file will be included to clang call with -I flag. Don't worry, it
+	 * doesn't ruin anything. It will not be included if this flag is set to
+	 * false.
+	 */
+	"include_file_parent_folder" : "true",
 
 	/* Allow to change the binary or location of clang program */
 	// "clang_binary" : "\"C:\\Program Files (x86)\\LLVM\\bin\\clang++\""

--- a/ClangAutoComplete.sublime-settings
+++ b/ClangAutoComplete.sublime-settings
@@ -25,7 +25,7 @@
 	 * if verbose is set to false, the plugin will output nothing.
 	 * else it will show the paths that it has found.
 	 */
-	"verbose" : "true",
+	"verbose" : "false",
 
 	/*
 	 * if include_file_parent_folder is set to true, the parent folder of the
@@ -33,7 +33,7 @@
 	 * doesn't ruin anything. It will not be included if this flag is set to
 	 * false.
 	 */
-	"include_file_parent_folder" : "true",
+	"include_file_parent_folder" : "false",
 
 	/* Allow to change the binary or location of clang program */
 	// "clang_binary" : "\"C:\\Program Files (x86)\\LLVM\\bin\\clang++\""

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -20,7 +20,14 @@
                                 {
                                     "file": "${packages}/ClangAutoComplete/ClangAutoComplete.sublime-settings"
                                 },
-                                "caption": "Settings"
+                                "caption": "Settings - Default"
+                            },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/User/ClangAutoComplete.sublime-settings"
+                                },
+                                "caption": "Settings - User"
                             }
                         ]
                     }


### PR DESCRIPTION
- switch to using sublime-provided way of getting current variables
- switch to absolute project path (should work on Windows too, but not tested)
- replace all by-hand path creation by using `os.path` way where found
- add verbose flag to enable showing found folders (like project, current file)
- add an option to include the file's parent folder to include folders
- add a new menu entry that allows the user to create a user settings file which will not be overwritten my an upgrade to the new version. The user has to populate it himself upon package installation. This should close issue #15 
- remove some annoying trailing spaces

The include paths relative to the project have not worked for me, so I have rewritten that part to provide absolute path. Also, sublime module provides us with paths for everything we care about, like project folder or current file path. 

I have also added a option to show the paths that the code has guessed with the "verbose" flag. The flag is false by default.

Another added option is to add the parent folder of current file to the include paths as I usually code in packages and the include paths in every file is relative to the package parent folder. There is a flag in setting to enable/disable this. The flag is false by default.

+ some cleanups like replacing all places where the paths were constructed manually with the os.path way. This should be cross platform, but I haven't checked it on windows. (I am on linux). 

Feel free to criticize this and tell me what you think. I am happy to include the suggestions you might have.

Overall, this is the best package for clang based completion and I thank you for your work :+1:  