### PR TITLE
Add std library flag

### DIFF
--- a/ClangAutoComplete.py
+++ b/ClangAutoComplete.py
@@ -100,7 +100,7 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 		# decide based on file extension.
 		syntax_flags = None
 		c_flags = ""
-		cpp_flags = "-x c++"
+		cpp_flags = self.std_flag + " -x c++"
 		if view.settings().get('syntax') is not None:
 			syntax = re.findall(self.syntax_regex, view.settings().get('syntax'))
 			if len(syntax) > 0:
@@ -118,7 +118,7 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 
 		# Build clang command
 		clang_bin = self.clang_binary
-		clang_flags = "-cc1 " + self.std_flag + " " + syntax_flags + " -fsyntax-only"
+		clang_flags = "-cc1 " + syntax_flags + " -fsyntax-only"
 		clang_target = "-code-completion-at " + self.tmp_file_path+":"+str(line_pos)+":"+str(char_pos ) +" "+self.tmp_file_path
 		clang_includes=" -I ."
 		for dir in self.include_dirs:

--- a/ClangAutoComplete.py
+++ b/ClangAutoComplete.py
@@ -51,7 +51,7 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 		self.selectors        = settings.get("selectors")
 		self.include_dirs     = settings.get("include_dirs")
 		self.clang_binary     = settings.get("clang_binary")
-		self.std_flag     		= settings.get("std_flag")
+		self.std_flag         = settings.get("std_flag")
 
 		if (not self.std_flag):
 			self.std_flag = "-std=c++11"

--- a/ClangAutoComplete.py
+++ b/ClangAutoComplete.py
@@ -51,6 +51,7 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 		self.selectors        = settings.get("selectors")
 		self.include_dirs     = settings.get("include_dirs")
 		self.clang_binary     = settings.get("clang_binary")
+		self.std_flag     		= settings.get("std_flag")
 
 		for include_dir in self.include_dirs:
 			include_dir = re.sub("(\$project_base_path)", project_path, include_dir)
@@ -110,7 +111,7 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 
 		# Build clang command
 		clang_bin = self.clang_binary
-		clang_flags = "-cc1 " + syntax_flags + " -fsyntax-only"
+		clang_flags = "-cc1 " + self.std_flag + " " + syntax_flags + " -fsyntax-only"
 		clang_target = "-code-completion-at " + self.tmp_file_path+":"+str(line_pos)+":"+str(char_pos ) +" "+self.tmp_file_path
 		clang_includes=" -I ."
 		for dir in self.include_dirs:

--- a/ClangAutoComplete.py
+++ b/ClangAutoComplete.py
@@ -53,6 +53,11 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 		self.clang_binary     = settings.get("clang_binary")
 		self.std_flag     		= settings.get("std_flag")
 
+		if (not self.std_flag):
+			self.std_flag = "-std=c++11"
+			if (self.verbose):
+				print("set std_flag to default: '{}'".format(self.std_flag))
+
 		for i, include_dir in enumerate(self.include_dirs):
 			include_dir = re.sub("(\$project_base_path)", project_path, include_dir)
 			include_dir = re.sub("(\$project_name)", project_name, include_dir)
@@ -63,6 +68,7 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 			print("project_base_name = {}".format(project_name))
 			print("folder = {}".format(project_path))
 			print("file_parent_folder = {}".format(file_parent_folder))
+			print("std_flag = {}".format(self.std_flag))
 
 		if (include_parent_folder):
 			self.include_dirs.append(file_parent_folder)

--- a/ClangAutoComplete.sublime-settings
+++ b/ClangAutoComplete.sublime-settings
@@ -37,5 +37,8 @@
 
 	/* Allow to change the binary or location of clang program */
 	// "clang_binary" : "\"C:\\Program Files (x86)\\LLVM\\bin\\clang++\""
-	"clang_binary" : "clang++"
+	"clang_binary" : "clang++",
+
+  /* setting the standard library flag. */
+  "std_flag" : "-std=c++11"
 }

--- a/ClangAutoComplete.sublime-settings
+++ b/ClangAutoComplete.sublime-settings
@@ -1,10 +1,10 @@
 {
 	/* Header files to fetch completion information from */
 	"include_dirs" : [
-					  "/usr/include",
-					  "$project_base_path/src",
-					  "/workspace/$project_name/src",
-					  ],
+						"/usr/include",
+						"$project_base_path/src",
+						"/workspace/$project_name/src",
+						],
 	/* Temporary file where current file will be written to */
 	// "tmp_file_path" : "/tmp/auto_complete_tmp",
 	/* If file encoding was not detected, assume this instead */
@@ -39,6 +39,6 @@
 	// "clang_binary" : "\"C:\\Program Files (x86)\\LLVM\\bin\\clang++\""
 	"clang_binary" : "clang++",
 
-  /* setting the standard library flag. */
-  "std_flag" : "-std=c++11"
+	/* setting the standard library flag. */
+	"std_flag" : "-std=c++11"
 }


### PR DESCRIPTION
Hey @pl-ca ! It's me again :)

I'm using your plugin mostly with c++11 code, so I decided to add a separate flag for specifying the standard version. It should be a trivial change. Hope it is welcome.

Sorry for many commits. I have figured out that I have used spaces instead of tabs in settings and I have moved to using tabs everywhere. 