### PR TITLE
Added option exclude_system_folders

### DIFF
--- a/ClangAutoComplete.py
+++ b/ClangAutoComplete.py
@@ -57,6 +57,7 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 			settings = sublime.load_settings("ClangAutoComplete.sublime-settings")
 
 		include_parent_folder = self.to_bool(settings.get("include_file_parent_folder"))
+		exclude_system_folders = self.to_bool(settings.get("exclude_system_folders"))
 		self.complete_all = self.to_bool(settings.get("autocomplete_all"))
 		self.verbose = self.to_bool(settings.get("verbose"))
 		self.tmp_file_path = settings.get("tmp_file_path")
@@ -89,7 +90,8 @@ class ClangAutoComplete(sublime_plugin.EventListener):
 			self.include_dirs[i] = include_dir
 
 		# Prepend standard headers (if anything to prepend) to the custom include directories
-		self.include_dirs = std_headers + self.include_dirs
+		if (not exclude_system_folders):
+			self.include_dirs = std_headers + self.include_dirs
 
 		if (self.verbose):
 			print("project_base_name = {}".format(project_name))

--- a/ClangAutoComplete.sublime-settings
+++ b/ClangAutoComplete.sublime-settings
@@ -42,6 +42,13 @@
 	 */
 	"include_file_parent_folder" : "false",
 
+	/*
+	 * If exclude_system_folders is set to true, the system include folders
+	 * will be excluded from clang call in -I flags.
+	 * This setting is for embedded projects, like Linux kernel or baremetal.
+	 */
+	"exclude_system_folders" : "false",
+
 	/* Allow to change the binary or location of clang program */
 	// "clang_binary" : "\"C:\\Program Files (x86)\\LLVM\\bin\\clang++\""
 	"clang_binary" : "clang++",


### PR DESCRIPTION
Hello.
I've added an option exclude_system_folders. In a projects like embedded baremetal or Linux kernel there is no need to search for header files in system include folders.
Please review my changes.
Best regards,
Anton.